### PR TITLE
Fix terrain data insertion for newly generated rooms

### DIFF
--- a/lib/cli/map.js
+++ b/lib/cli/map.js
@@ -595,7 +595,7 @@ exports.generateRoom = utils.withHelp([
 
                 return q.all([
                     db.rooms.insert({_id: roomName, status: 'normal', active: true, sourceKeepers}),
-                    db['rooms.terrain'].insert({room: roomName, terrain}),
+                    db['rooms.terrain'].insert({room: roomName, terrain, type: 'terrain'}),
                     objects.length ? db['rooms.objects'].insert(objects) : q.when()
                 ]);
             })


### PR DESCRIPTION
This updates map.js's `generateRoom` function to input a correctly-formed terrain data item into the database.

I'm not sure this is the entire fix, or even if this changes the behavior in the right location, but it does fix creeps not spawning in new rooms.

I haven't done extensive testing, but this does seem initially like a complete fix for http://support.screeps.com/hc/en-us/community/posts/209656209-Error-in-engine-processor-spawning-creep-after-setting-custom-terrain.