### PR TITLE
Fixed info leak on map-stats endpoint

### DIFF
--- a/lib/game/api/game.js
+++ b/lib/game/api/game.js
@@ -228,7 +228,7 @@ router.post('/map-stats', auth.tokenAuth, jsonResponse((request) => {
             })
         })
     })
-    .then(() => db.users.find({_id: {$in: _.keys(users)}}))
+    .then(() => db.users.find({_id: {$in: _.keys(users)}},{ _id: true, username: true, badge: true }))
     .then(users => ({
         gameTime,
         stats,

--- a/lib/game/socket/rooms.js
+++ b/lib/game/socket/rooms.js
@@ -111,7 +111,7 @@ module.exports = function(listen, emit) {
                             unknownUserIds = _.uniq(unknownUserIds);
 
                             eventResultPromises.push(
-                                db.users.find({_id: {$in: unknownUserIds}})
+                                db.users.find({_id: {$in: unknownUserIds}},{ username: true, badge: true })
                                     .then((unknownUsers) => {
                                         unknownUsers.forEach((user) => i.users[user._id.toString()] = user);
                                         unknownUsers = _.reduce(unknownUsers, (result, user) => {
@@ -179,7 +179,7 @@ module.exports = function(listen, emit) {
                         }, []);
                         userIds = _.uniq(userIds);
                         return q.all([
-                            db.users.find({_id: {$in: userIds}}),
+                            db.users.find({_id: {$in: userIds}},{ username: true, badge: true }),
                             db['rooms.flags'].findOne({$and: [{room: roomName}, {user: ""+user._id}]})
                         ]);
                     })


### PR DESCRIPTION
The map-stats endpoint was leaking full user objects, it should only return the username and badge to match official and protect the user's data.

Thanks to @esyrok and @daboross for finding and showing me this on one of my servers :)