### PR TITLE
Update /api/user/memory/ to use gzip to be consistent with official

### DIFF
--- a/lib/game/api/user.js
+++ b/lib/game/api/user.js
@@ -271,7 +271,7 @@ router.get('/memory', auth.tokenAuth, jsonResponse((request) => {
                     return {data: curPointer};
                 }
 
-                return q.ninvoke(zlib, 'deflate', JSON.stringify(curPointer))
+                return q.ninvoke(zlib, 'gzip', JSON.stringify(curPointer))
                     .then(gzipped => ({data: 'gz:'+btoa(gzipped)}));
             }
             catch(e) {


### PR DESCRIPTION
This updates /api/user/memory to use gzip. This makes it
consistent with official. The only breaking affects will
be the third party libraries that currently alter their
parsing to work with both.