### PR TITLE
don't randomly spawn bots on bottom/right edge of room

### DIFF
--- a/lib/cli/bots.js
+++ b/lib/cli/bots.js
@@ -94,11 +94,11 @@ exports.spawn = utils.withHelp([
                 .then(() => env.set(env.keys.MEMORY+user._id, "{}"))
                 .then(() => db['rooms.terrain'].findOne({room: roomName}))
                 .then(terrainItem => {
-                    var x = opts.x || Math.floor(3 + Math.random()*46);
-                    var y = opts.y || Math.floor(3 + Math.random()*46);
+                    var x = opts.x || Math.floor(3 + Math.random()*44);
+                    var y = opts.y || Math.floor(3 + Math.random()*44);
                     while(common.checkTerrain(terrainItem.terrain, x, y, C.TERRAIN_MASK_WALL)) {
-                        x = Math.floor(3 + Math.random()*46);
-                        y = Math.floor(3 + Math.random()*46);
+                        x = Math.floor(3 + Math.random()*44);
+                        y = Math.floor(3 + Math.random()*44);
                     }
                     return db['rooms.objects'].insert({
                         type: 'spawn',


### PR DESCRIPTION
The existing code avoids the top/left three squares, but only the bottom/right one square. I opted to honor the three, rather than making both two.

Fixes https://github.com/screeps/engine/issues/25