### PR TITLE
Update NPC Cron energy prices

### DIFF
--- a/lib/cronjobs.js
+++ b/lib/cronjobs.js
@@ -96,7 +96,7 @@ function recreateNpcOrders() {
                             remainingAmount: period*sellEnergyAmount,
                             totalAmount: period*sellEnergyAmount,
                             resourceType: 'energy',
-                            price: 1,
+                            price: 1000,
                             roomName: terminal.room
                         });
                     }


### PR DESCRIPTION
This updates the energy sell price from 1 to 1000, so the actual market price is now 1.0 rather than 0.001. 
(Forum bug report for reference, its also come up a few times in slack)  https://screeps.com/forum/topic/2060/a-couple-of-private-server-market-bugs)