### PR TITLE
In market history, show balance after transaction

### DIFF
--- a/lib/game/api/user.js
+++ b/lib/game/api/user.js
@@ -454,9 +454,10 @@ router.get('/money-history', auth.tokenAuth, jsonResponse((request) => {
     return db['users.money'].findEx({user: request.user._id}, {sort: {date: -1}, skip: page*pageSize, limit: pageSize+1})
         .then(data => {
             var spliced = data.splice(0, pageSize);
+            var calculated = spliced.map((row)=>{row.balance += row.change; return row;});
             return {
                 page,
-                list: spliced,
+                list: calculated,
                 hasMore: data.length > 0
             };
         })


### PR DESCRIPTION
This only changes how the client receives it. The database stays unchanged. This could also be done in the UI (since it's no mass data), maybe this should be a user setting?

This fixes the last of [a-couple-of-private-server-market-bugs](https://screeps.com/forum/topic/2060/a-couple-of-private-server-market-bugs).