### PR TITLE
Expose hidden console option to external API

### DIFF
--- a/lib/game/api/user.js
+++ b/lib/game/api/user.js
@@ -346,7 +346,8 @@ router.post('/console', auth.tokenAuth, jsonResponse((request) => {
 
     return db['users.console'].insert({
         user: request.user._id,
-        expression: request.body.expression
+        expression: request.body.expression,
+        hidden: !!request.body.hidden
     });
 }));
 


### PR DESCRIPTION
This will allow for additional options for third-party tools to push to the console without spamming it with results. It simply checks for a `hidden` option in the post body request, will default to `false` if it is not included in the request (for backward compatibility), and is forced into a boolean with `!!`.