### PR TITLE
Check existence of expression in console endpoint

### DIFF
--- a/lib/game/api/user.js
+++ b/lib/game/api/user.js
@@ -339,8 +339,11 @@ router.post('/memory-segment', auth.tokenAuth, jsonResponse((request) => {
 }));
 
 router.post('/console', auth.tokenAuth, jsonResponse((request) => {
-
-    if(JSON.stringify(request.body.expression).length > 1024) {
+    var expression = JSON.stringify(request.body.expression);
+    if (expression === undefined) {
+        return q.reject('invalid expression');
+    }
+    if(expression.length > 1024) {
         return q.reject('expression size is too large');
     }
 


### PR DESCRIPTION
Previously, using the `/api/user/console` endpoint and specifying a shard but not an expression resulted in the user being sent a `TypeError` description in the response JSON. Now, the user is told that the expression is invalid.

The error expression was chosen to be similar to that for an invalid shard.