### PR TITLE
Fixes help(bots)

### DIFF
--- a/lib/cli/bots.js
+++ b/lib/cli/bots.js
@@ -47,7 +47,7 @@ function genRandomBadge() {
 
 exports.spawn = utils.withHelp([
     `spawn(botAiName, roomName, [opts]) - Create a new NPC player with bot AI scripts, and spawn it to the specified room. 'opts' is an object with the following optional properties:\r
-    * name - the name of a bot player, default is randomly generated\r
+    * username - the name of a bot player, default is randomly generated\r
     * cpu - the CPU limit of a bot user, default is 100\r
     * gcl - the Global Control Level of a bot user, default is 1\r
     * x - the X position of the spawn in the room, default is random\r


### PR DESCRIPTION
This fixes `help(bots)` to show correct parameter for bot username.