### PR TITLE
Allow loading .wasm files from bots loaded as modules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -260,10 +260,16 @@ exports.loadBot = function(name) {
     var files = fs.readdirSync(dir), modules = {};
     files.forEach(file => {
         var m = file.match(/^(.*)\.js$/);
-        if(!m) {
-            return;
+        if(m) {
+            modules[m[1]] = fs.readFileSync(path.resolve(dir, file), {encoding: 'utf8'});
+        } else {
+            var wm = file.match(/^(.*)\.wasm$/);
+            if(wm) {
+                modules[wm[1]] = {
+                    binary: fs.readFileSync(path.resolve(dir, file), {encoding: 'base64'}),
+                };
+            }
         }
-        modules[m[1]] = fs.readFileSync(path.resolve(dir, file), {encoding: 'utf8'});
     });
     return exports.translateModulesToDb(modules);
 };


### PR DESCRIPTION
Currently, bots loaded as on-disk modules via `utils.loadBot` have `.wasm` files skipped/excluded, rendering WebAssembly bots unable to be loaded as node modules. This updates the function to load `.wasm` files with the appropriate base64 conversion for the database.