### PR TITLE
fix: api/game/room-terrain returning encoded terrain data in all cases

### DIFF
--- a/lib/cli/map.js
+++ b/lib/cli/map.js
@@ -555,7 +555,7 @@ exports.generateRoom = utils.withHelp([
 
                 return q.all([
                     db.rooms.insert({_id: roomName, status: 'normal', sourceKeepers}),
-                    db['rooms.terrain'].insert({room: roomName, terrain}),
+                    db['rooms.terrain'].insert({room: roomName, terrain, type: "terrain"}),
                     objects.length ? db['rooms.objects'].insert(objects) : q.when()
                 ]);
             })

--- a/lib/game/api/game.js
+++ b/lib/game/api/game.js
@@ -270,7 +270,7 @@ router.get('/room-terrain', jsonResponse((request) => {
         if(request.query.encoded) {
             return {terrain};
         }
-        if(terrain.length == 1 && terrain[0].type == 'terrain') {
+        if(terrain.length == 1 && typeof terrain[0].terrain === 'string') {
             return {terrain: common.decodeTerrain(terrain[0].terrain, request.query.room)};
         }
         return {terrain};


### PR DESCRIPTION
As rooms generated via the `map.generateRoom` CLI command would never set `type: "terrain"`, the check for decoding those would always fail, leading to encoded terrain being returned whether the `&encoded` param was set or not.

Fix the issue by always decoding if a string `terrain` key is found on a single-result return, but for consistency, also fix `generateRoom` to add that `type` property.