### PR TITLE
Remove signs when performing bots.removeUser

### DIFF
--- a/lib/cli/bots.js
+++ b/lib/cli/bots.js
@@ -148,6 +148,7 @@ exports.removeUser = utils.withHelp([
                     return q.reject('User is not a bot');
                 }
                 return utils.respawnUser(user._id)
+                    .then(db['rooms.objects'].update({'sign.user':user._id},{$unset:{sign:true}}))
                     .then(db.users.removeWhere({_id: user._id}))
                     .then(db['users.code'].removeWhere({user: user._id}))
                     .then(env.del(env.keys.MEMORY+user._id))


### PR DESCRIPTION
After performing `bots.removeUser(foo)`, the controllers signed by that bot are left in an invalid state. Attempting to access the controller sign (just access, not even access its properties or modify it) via the game API produces an error:

```
TypeError: Cannot read property 'username' of undefined
    at Object.sign (:25687:58)
    at Object.get [as sign] (eval at exports.defineGameObjectProperties (:586:9), :7:59)
```

The error is caused by `StructureController.sign.user` referring to a nonexistent user id, breaking the lookup performed by this getter https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/utils.js#L521-L525 attempting to look up this property https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L193.

This PR adds a step to removeUser that un-signs controllers signed by the user being removed.

Possible alternative solutions:
* Change the sign to be owned by Screeps, possibly with some extra text mentioning the previous owner.
* Allow `StructureController.sign.username` to be undefined if the user whose id is in sign.user doesn't exist.