### PR TITLE
Change the way the top-level `help()` message is generated

### DIFF
--- a/lib/cli/bots.js
+++ b/lib/cli/bots.js
@@ -156,5 +156,6 @@ exports.removeUser = utils.withHelp([
     }
 ]);
 
-exports._help = utils.generateCliHelp('bots.', exports)+`\r\nBot AIs:\r\n`+
+exports._help = utils.generateCliHelp('bots.', exports, "Manage NPC bot players and their AI scripts.") + 
+    `\r\nBot AIs:\r\n` +
     Object.keys(bots).map(botName => ` - ${botName} [${bots[botName]}]`).join(`\r\n`);

--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -1,15 +1,5 @@
 var common = require('@screeps/common');
 
-var help = `The supported commands are:\r
-    * help() - Print this help text.\r
-    * print(value) - Print a value to the console.\r
-    * storage - A global database storage object.\r
-    * map - Map editing functions.\r
-    * bots - Manage NPC bot players and their AI scripts.\r
-    * strongholds - Manage NPC Strongholds\r
-    * system - System utility functions.\r
-Type help(object) to learn more about specific usage of the object.`;
-
 var storageHelp = {
     main: `This is the main storage object that allows to perform direct operations on the game database. It contains 3 sub-objects:\r
     * db - An object containing all database collections in it. Use it to fetch or modify game objects. The database is based on LokiJS project, so you can learn more about available functionality in its documentation.
@@ -42,28 +32,35 @@ Example: storage.pubsub.subscribe(storage.pubsub.keys.ROOMS_DONE, (gameTime) => 
 
 
 
-function helpFn(object) {
-    if(object === undefined) {
-        return help;
-    }
-    if(object === this.storage) {
-        return storageHelp.main;
-    }
-    if(object === this.storage.db) {
-        return storageHelp.db;
-    }
-    if(object === this.storage.env) {
-        return storageHelp.env;
-    }
-    if(object === this.storage.pubsub) {
-        return storageHelp.pubsub;
-    }
-    if(object._help) {
-        return object._help;
-    }
-    return 'There is no help page for this object.';
-}
-
 module.exports = function cliHelp(sandbox) {
-    sandbox.help = helpFn.bind(sandbox);
+    const helpCmd = function helpFn(object) {
+        if(object === undefined) {
+            const cmdList = Object.keys(sandbox)
+                .filter(k => sandbox[k]._desc)
+                .map(k => {
+                    const [args, desc] = Array.isArray(sandbox[k]._desc) ? sandbox[k]._desc : [typeof sandbox[k] === "function" ? "()" : "", sandbox[k]._desc];
+                    return `* ${k}${args} - ${desc}\r\n`
+                })
+                .join('');
+            return `The supported commands are:\r\n${cmdList}Type help(object) to learn more about specific usage of the object.`;
+        }
+        if(object === sandbox.storage) {
+            return storageHelp.main;
+        }
+        if(object === sandbox.storage.db) {
+            return storageHelp.db;
+        }
+        if(object === sandbox.storage.env) {
+            return storageHelp.env;
+        }
+        if(object === sandbox.storage.pubsub) {
+            return storageHelp.pubsub;
+        }
+        if(object._help) {
+            return object._help;
+        }
+        return 'There is no help page for this object.';
+    }
+    helpCmd._desc = "Print this help text."
+    return helpCmd;
 };

--- a/lib/cli/map.js
+++ b/lib/cli/map.js
@@ -695,4 +695,4 @@ exports.updateTerrainData = utils.withHelp([
 }]);
 
 
-exports._help = utils.generateCliHelp('map.', exports);
+exports._help = utils.generateCliHelp('map.', exports, "Map editing functions.");

--- a/lib/cli/sandbox.js
+++ b/lib/cli/sandbox.js
@@ -8,18 +8,21 @@ Object.assign(config.cli, {
         if(!/at Object\.create/.test(new Error().stack.split(/\n/)[2])) {
             console.error("config.cli.createSandbox is deprecated, please use config.cli.onCliSandbox instead");
         }
-        var sandbox = {
-            print() {
-                outputCallback(Array.prototype.slice.apply(arguments).map( i => util.inspect(i)).join(" "));
-            },
-            storage: common.storage,
-            map: require('./map'),
-            bots: require('./bots'),
-            strongholds: require('./strongholds'),
-            system: require('./system')
-        };
 
-        require('./help')(sandbox);
+        var sandbox = {};
+
+        sandbox.help = require('./help')(sandbox);
+        sandbox.print = function () { outputCallback(Array.prototype.slice.apply(arguments).map( i => util.inspect(i)).join(" ")) };
+        sandbox.print._desc = ["(value)", "Print a value to the console."];
+
+        sandbox.storage = common.storage;
+        sandbox.storage._desc = "A global database storage object.";
+
+        // Those have their desc set by `generateCliHelp`
+        sandbox.map = require('./map');
+        sandbox.bots = require('./bots');
+        sandbox.strongholds = require('./strongholds');
+        sandbox.system = require('./system');
 
         config.cli.emit('cliSandbox',sandbox);
 
@@ -52,7 +55,7 @@ function create(outputCallback) {
 
         }
         catch(e) {
-            outputCallback(e.toString(), true);
+            outputCallback(e.toString() + "\r\n" + e.stack, true);
         }
     };
 }

--- a/lib/cli/strongholds.js
+++ b/lib/cli/strongholds.js
@@ -38,6 +38,6 @@ exports.expand = utils.withHelp([
     }
 ]);
 
-exports._help = utils.generateCliHelp('strongholds.', exports) +
+exports._help = utils.generateCliHelp('strongholds.', exports, "Manage NPC Strongholds.") +
     `\r\nStronghold templates:\r\n`+
     Object.keys(strongholds.templates).map(n => ` - ${n} [${strongholds.templates[n].description}]`).join(`\r\n`);

--- a/lib/cli/system.js
+++ b/lib/cli/system.js
@@ -71,4 +71,4 @@ exports.setTickDuration = utils.withHelp([
     }
 ]);
 
-exports._help = utils.generateCliHelp('system.', exports);
+exports._help = utils.generateCliHelp('system.', exports, "System utility functions.");

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -173,8 +173,17 @@ exports.withHelp = function(array) {
     return fn;
 };
 
-exports.generateCliHelp = function(prefix, container) {
-    return `Available methods:\r\n`+Object.keys(container).filter(i => typeof container[i] == 'function').map(i => ' - ' + prefix + (container[i]._help || i)).join('\r\n');
+exports.generateCliHelp = function(prefix, container, desc) {
+    const subhelp = Object.keys(container)
+        .filter(i => typeof container[i] == 'function')
+        .map(i => ' - ' + prefix + (container[i]._help || i))
+        .join('\r\n')
+    container._help = `Available methods:\r\n${subhelp}`;
+    if (desc) {
+        container._desc = desc;
+    }
+    console.log(`generating help for ${prefix}, ${desc}`);
+    return container._help;
 };
 
 exports.writePng = function(colors, width, height, filename) {


### PR DESCRIPTION
This changes `generateCliHelp` to add a `_desc` property that can be used to set the name of the "category" the `help()` command will show for a given object.

This allows mods, like screepsmod-admin-utils to properly show up in the `help()` command list instead of being earmouthed around.

Said `_desc` property is either a string, in which case the key it applies to will automatically get `()` added and the string used as the description for it, or an array of two strings, the first one being the argument names and the second the description.

Example output with some of the mods updated to take advantage of this feature:
```
> help()
The supported commands are:
* help() - Print this help text.
* print(value) - Print a value to the console.
* storage - A global database storage object.
* map - Map editing functions.
* bots - Manage NPC bot players and their AI scripts.
* strongholds - Manage NPC Strongholds.
* system - System utility functions.
* utils - Extended screepsmod-admin-utils commands
* setPassword(username, password) - Reset a user's password
* mongo - MongoDB management commands
Type help(object) to learn more about specific usage of the object.
> 
```