### PR TITLE
🔨 Add a safe zone when placing powerbanks

### DIFF
--- a/lib/cronjobs.js
+++ b/lib/cronjobs.js
@@ -208,9 +208,11 @@ async function genPowerBanks() {
         }
 
         room.powerBankTime = gameTime + respawnTime;
+        const objects = await db['rooms.objects'].find({room: room._id});
         const data = await db['rooms.terrain'].findOne({room: room._id});
-        let x, y, isWall, hasExit;
+        let x, y, isWall, hasExit, nearObjects, cnt=1000;
         do {
+            if (--cnt < 0) break;
             x = Math.floor(Math.random() * 40 + 5);
             y = Math.floor(Math.random() * 40 + 5);
             isWall = parseInt(data.terrain.charAt(y * 50 + x)) & 1;
@@ -222,8 +224,13 @@ async function genPowerBanks() {
                     }
                 }
             }
+            nearObjects = _.any(objects, obj => Math.abs(obj.x-x) <= 2 && Math.abs(obj.y-y) <= 2);
         }
-        while (!isWall || !hasExit);
+        while (!isWall || !hasExit || nearObjects);
+        if (cnt === 0) {
+            console.log(`cannot find location in ${room._id}`);
+            continue;
+        }
         let power = Math.floor(Math.random() * (C.POWER_BANK_CAPACITY_MAX - C.POWER_BANK_CAPACITY_MIN) + C.POWER_BANK_CAPACITY_MIN);
         if (Math.random() < C.POWER_BANK_CAPACITY_CRIT) {
             power += C.POWER_BANK_CAPACITY_MAX;


### PR DESCRIPTION
This popped up on Thunderdrone 3. Looking around, deposits do have an exclusion zone, so what likely happened is deposit went in, then powerbank went in.

Fix the issue by adding the same sort of object-closeness check to the powerbank placement.

<img width="374" height="297" alt="image-7" src="https://github.com/user-attachments/assets/19767ea3-1bb9-4e8b-8b80-09130eada3c5" />
