### PR TITLE
Restore room status on respawn

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,7 +144,7 @@ exports.respawnUser = async function(userId) {
             await db['rooms.objects'].update({user: "" + userId, type: 'ruin'}, {$set: {user: ""+systemUser._id}});
             await db['rooms.objects'].removeWhere({user: "" + userId, type: {$ne: 'controller'}});
             await db['rooms.flags'].removeWhere({user: ""+userId});
-            const controllers = db['rooms.objects'].find({$and: [{user: ""+userId}, {type: 'controller'}]});
+            const controllers = await db['rooms.objects'].find({$and: [{user: ""+userId}, {type: 'controller'}]});
             for(let i in controllers) {
                 await db.rooms.update({_id: controllers[i].room}, {$set: {status: 'normal'}});
             }


### PR DESCRIPTION
## What changed

Await the controller query before restoring each affected room to `normal` status during respawn.

## Why

`db['rooms.objects'].find(...)` returns a promise, but `respawnUser` iterated that promise directly. The loop therefore never visited the user's controllers and the intended `db.rooms.update(...)` calls did not run.

This resolves the query first so every former controller room is restored before the respawn operation completes.

## Validation

- `node --check lib/utils.js`
- Mocked the respawn database flow: current upstream performs no room updates; this change restores the controller's room
